### PR TITLE
ci: surface appflowy_search log targets in cloud integration runs

### DIFF
--- a/.github/workflows/cloud_integration_ci.yaml
+++ b/.github/workflows/cloud_integration_ci.yaml
@@ -365,7 +365,12 @@ jobs:
       - name: Replace values in .env
         run: |
           # log level
-          sed -i 's|RUST_LOG=.*|RUST_LOG='appflowy_cloud=info,appflowy_worker=debug,appflowy_collaborate=info,indexer=info'|' .env
+          # appflowy_search + search targets included so the search service's
+          # startup decisions (S3 bootstrap, worker spawn/skip reasons) appear
+          # in the "Show appflowy_search startup logs" step — without them a
+          # skipped ensure worker is invisible and search test failures look
+          # like flaky timeouts.
+          sed -i 's|RUST_LOG=.*|RUST_LOG='appflowy_cloud=info,appflowy_worker=debug,appflowy_collaborate=info,indexer=info,appflowy_search=info,search=info'|' .env
           sed -i 's|GOTRUE_SMTP_USER=.*|GOTRUE_SMTP_USER=${{ secrets.CI_GOTRUE_SMTP_USER }}|' .env
           sed -i 's|GOTRUE_SMTP_PASS=.*|GOTRUE_SMTP_PASS=${{ secrets.CI_GOTRUE_SMTP_PASS }}|' .env
           sed -i 's|GOTRUE_SMTP_ADMIN_EMAIL=.*|GOTRUE_SMTP_ADMIN_EMAIL=${{ secrets.CI_GOTRUE_SMTP_ADMIN_EMAIL }}|' .env


### PR DESCRIPTION
## Why

`search::database_row_search::database_row_index_ensure_indexes_missing_rows_and_deletes_stale_rows` has been failing on every cloud integration run with a 180s timeout. The root cause is in the cloud repo (the `appflowy_search` service in `docker-compose-ci.yml` gets no `APPFLOWY_S3_*` env, so its S3 bootstrap fails, `CollabStore` is `None`, and the database-row index ensure worker silently never starts) — fixed in AppFlowy-IO/AppFlowy-Cloud-Premium#736.

It stayed misdiagnosed as a flaky timeout because this workflow's `RUST_LOG` filter (`appflowy_cloud=info,appflowy_worker=debug,appflowy_collaborate=info,indexer=info`) drops every log line the search service emits under `appflowy_search::*` and `search::*` — including the two lines that name the problem directly: `S3 bootstrap failed; … Configure APPFLOWY_S3_* env vars on the appflowy_search …` and `collab store unavailable; skipping ensure worker`. The dedicated "Show appflowy_search startup logs" step was dumping a service that was logging almost nothing.

## Change

Add `appflowy_search=info,search=info` to the `RUST_LOG` sed line so search-service startup decisions (S3 bootstrap result, which workers spawned or were skipped and why) are visible in run logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)