### PR TITLE
ci: update AppFlowy AI to 0.13.2

### DIFF
--- a/.github/workflows/cloud_integration_ci.yaml
+++ b/.github/workflows/cloud_integration_ci.yaml
@@ -565,7 +565,7 @@ jobs:
           export APPFLOWY_SEARCH_VERSION=latest-amd64
           export APPFLOWY_ADMIN_FRONTEND_VERSION=latest-amd64
           # Keep this aligned with AppFlowy-Cloud-Premium's integration workflow.
-          export APPFLOWY_AI_VERSION=0.12.1-amd64
+          export APPFLOWY_AI_VERSION=0.13.2-amd64
           sudo rm -rf /tmp/minio-data || true
           echo "Starting services (using locally built images, pulling only missing ones)..."
           docker compose -f docker-compose-ci.yml up -d --pull=missing


### PR DESCRIPTION
Align the external Cloud integration workflow with AppFlowy-Cloud-Premium by updating the pinned AppFlowy AI image from 0.12.1-amd64 to 0.13.2-amd64.

The newer image restores the v2 answer-stream compatibility route and fixes numeric answer_message_id query parsing used by the Cloud AI integration tests.