### PR TITLE
fix(ci): start Authentik for SCIM tests

### DIFF
--- a/.github/workflows/cloud_commercial_integration_ci.yaml
+++ b/.github/workflows/cloud_commercial_integration_ci.yaml
@@ -229,6 +229,9 @@ jobs:
           export APPFLOWY_CLOUD_VERSION=${{ env.CLOUD_VERSION }}
           export APPFLOWY_ADMIN_FRONTEND_VERSION=${{ env.CLOUD_VERSION }}
           export APPFLOWY_AI_VERSION=${{ env.CLOUD_VERSION }}
+          if [ "${{ matrix.test_service }}" = "appflowy_cloud_commercial" ]; then
+            export COMPOSE_PROFILES="${COMPOSE_PROFILES:+$COMPOSE_PROFILES,}authentik"
+          fi
           docker compose -f docker-compose-ci.yml down
           docker compose -f docker-compose-ci.yml up -d
 
@@ -236,6 +239,13 @@ jobs:
         run: |
           echo "Waiting for services to be ready..."
           timeout 300 bash -c 'until curl -f http://localhost/api/health 2>/dev/null; do sleep 5; done' || echo "Health check timeout - proceeding anyway"
+
+      - name: Wait for Authentik
+        if: matrix.test_service == 'appflowy_cloud_commercial'
+        run: |
+          echo "Waiting for Authentik..."
+          timeout 300 bash -c 'until curl -fsS http://localhost:9010/-/health/ready/ >/dev/null; do sleep 3; done'
+          echo "Authentik ready."
 
       - name: Install prerequisites
         run: |
@@ -294,3 +304,7 @@ jobs:
         run: |
           docker ps -a
           docker compose -f docker-compose-ci.yml logs appflowy_cloud
+          if [ "${{ matrix.test_service }}" = "appflowy_cloud_commercial" ]; then
+            docker compose -f docker-compose-ci.yml --profile authentik \
+              logs authentik-db authentik-server authentik-worker || true
+          fi

--- a/.github/workflows/cloud_integration_ci.yaml
+++ b/.github/workflows/cloud_integration_ci.yaml
@@ -574,6 +574,9 @@ jobs:
           export APPFLOWY_ADMIN_FRONTEND_VERSION=latest-amd64
           # Keep this aligned with AppFlowy-Cloud-Premium's integration workflow.
           export APPFLOWY_AI_VERSION=0.12.1-amd64
+          if [ "${{ matrix.test_service }}" = "appflowy_cloud_scim" ]; then
+            export COMPOSE_PROFILES="${COMPOSE_PROFILES:+$COMPOSE_PROFILES,}authentik"
+          fi
           sudo rm -rf /tmp/minio-data || true
           echo "Starting services (using locally built images, pulling only missing ones)..."
           docker compose -f docker-compose-ci.yml up -d --pull=missing
@@ -599,6 +602,13 @@ jobs:
             sleep 5
           done
           echo "Health check timeout after 300 seconds - proceeding anyway"
+
+      - name: Wait for Authentik
+        if: matrix.test_service == 'appflowy_cloud_scim'
+        run: |
+          echo "Waiting for Authentik..."
+          timeout 300 bash -c 'until curl -fsS http://localhost:9010/-/health/ready/ >/dev/null; do sleep 3; done'
+          echo "Authentik ready."
 
       - name: Wait for MinIO to be ready
         run: |
@@ -722,6 +732,10 @@ jobs:
           docker compose -f docker-compose-ci.yml logs appflowy_search > appflowy_search_logs.txt 2>&1 || true
           docker compose -f docker-compose-ci.yml logs ai > appflowy_ai_logs.txt 2>&1 || true
           docker compose -f docker-compose-ci.yml logs gotrue > gotrue_logs.txt 2>&1 || true
+          if [ "${{ matrix.test_service }}" = "appflowy_cloud_scim" ]; then
+            docker compose -f docker-compose-ci.yml --profile authentik \
+              logs authentik-db authentik-server authentik-worker > authentik_logs.txt 2>&1 || true
+          fi
 
       - name: Upload Logs as Artifact
         if: failure()
@@ -736,6 +750,7 @@ jobs:
             appflowy_search_logs.txt
             appflowy_ai_logs.txt
             gotrue_logs.txt
+            authentik_logs.txt
           retention-days: 1
 
   notify-webhook:


### PR DESCRIPTION
## Summary

- Activate the `authentik` Docker Compose profile for the `appflowy_cloud_scim` integration lane.
- Activate the same profile for the commercial lane that runs the real Authentik SCIM smoke test.
- Wait up to five minutes for Authentik's readiness endpoint before starting either test suite.
- Include Authentik database, server, and worker logs in failure diagnostics.

## Root cause

AppFlowy Cloud Premium moved the Authentik services behind an opt-in Compose profile so ordinary integration lanes do not start an unused IdP. The active AppFlowy-CI workflows still invoked `docker compose up` without enabling that profile. As a result, no Authentik container or port `9010` existed, and the Rust fixtures deterministically timed out while polling `/-/health/ready/`.

This fixes the orchestration rather than increasing the Rust timeout. Non-SCIM lanes continue to exclude Authentik.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/cloud_integration_ci.yaml .github/workflows/cloud_commercial_integration_ci.yaml`
- Parsed both workflow files with Ruby YAML
- `git diff --check`
- Verified the default Compose service graph excludes Authentik
- Verified `COMPOSE_PROFILES=authentik` includes `authentik-db`, `authentik-server`, and `authentik-worker`
