### PR TITLE
ci: install libclang for RocksDB builds

### DIFF
--- a/.github/workflows/flutter_ci.yaml
+++ b/.github/workflows/flutter_ci.yaml
@@ -131,7 +131,7 @@ jobs:
               sudo wget -qO /etc/apt/sources.list.d/dart_stable.list https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list
               sudo apt-get update
               sudo apt-get install -y --fix-broken
-              sudo apt-get install -y build-essential libsqlite3-dev libssl-dev clang cmake ninja-build pkg-config libgtk-3-dev libcurl4-openssl-dev libepoxy-dev
+              sudo apt-get install -y build-essential libsqlite3-dev libssl-dev clang libclang-dev cmake ninja-build pkg-config libgtk-3-dev libcurl4-openssl-dev libepoxy-dev
               sudo apt-get install keybinder-3.0 libnotify-dev libwayland-cursor0 libwayland-client0 libwayland-egl1 unzip liblzma-dev
               sudo apt-get install -y libmpv-dev mpv libasound2-dev
               # Install GStreamer for audioplayers_linux


### PR DESCRIPTION
## Summary

- install `libclang-dev` in the Linux prepare job that builds the Flutter FFI artifact
- keep the prerequisite scoped to the compiling job; downstream test jobs continue consuming the prepared artifact

## Why

The RocksDB 0.24 binding build uses clang-sys runtime loading. The failed Linux job had `clang`, but no `llvm-config` or loadable `libclang.so`, so clang-sys stopped before compiling AppFlowy.

The companion Cloud change explicitly enables runtime libclang discovery in the generated AppFlowy-Client dependency. Together, these changes cover Linux while avoiding a hard-coded macOS libclang path.

## Validation

- `git diff --check`
- `actionlint` passed for `.github/workflows/flutter_ci.yaml` with the workflow's five existing `actions-rs/toolchain@v1` runner-version warnings ignored

Related:

- AppFlowy-IO/AppFlowy-Cloud-Premium#913
- AppFlowy-IO/AppFlowy-Premium#1201
- failed run: https://github.com/AppFlowy-IO/AppFlowy-CI/actions/runs/30554644433/job/90911854966
