### PR TITLE
fix(ci): provide AI database compatibility DSN

### DIFF
--- a/.github/workflows/cloud_commercial_integration_ci.yaml
+++ b/.github/workflows/cloud_commercial_integration_ci.yaml
@@ -13,6 +13,9 @@ env:
   LOCALHOST_WS_V2: ws://localhost/ws/v2
   APPFLOWY_REDIS_URI: redis://redis:6379
   APPFLOWY_AI_REDIS_URL: redis://redis:6379
+  # CI-only compatibility DSN for Cloud revisions that require the AI runtime database.
+  # Cloud's role-specific lane verifies appflowy_ai_runtime; never use this owner DSN in production.
+  APPFLOWY_AI_DATABASE_URL: postgres://postgres:password@postgres:5432/postgres
   LOCALHOST_GOTRUE: http://localhost/gotrue
   POSTGRES_PASSWORD: password
   DATABASE_URL: postgres://postgres:password@localhost:5432/postgres

--- a/.github/workflows/cloud_integration_ci.yaml
+++ b/.github/workflows/cloud_integration_ci.yaml
@@ -31,6 +31,9 @@ env:
   APPFLOWY_MCP_TEST_BASE_URL: http://localhost:8002
   APPFLOWY_REDIS_URI: redis://redis:6379
   APPFLOWY_AI_REDIS_URL: redis://redis:6379
+  # CI-only compatibility DSN for Cloud revisions that require the AI runtime database.
+  # Cloud's role-specific lane verifies appflowy_ai_runtime; never use this owner DSN in production.
+  APPFLOWY_AI_DATABASE_URL: postgres://postgres:password@postgres:5432/postgres
   LOCALHOST_GOTRUE: http://localhost/gotrue
   POSTGRES_PASSWORD: password
   DATABASE_URL: postgres://postgres:password@localhost:5432/postgres

--- a/.github/workflows/self_host_cloud_docker.yml
+++ b/.github/workflows/self_host_cloud_docker.yml
@@ -548,7 +548,11 @@ jobs:
           images: registry.hub.docker.com/${{ env.IMAGE_NAME }}
 
       - name: Build ${{ matrix.job.name }}:${{ env.GIT_TAG }}
+        env:
+          AI_SOURCE_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          test -n "$AI_SOURCE_TOKEN"
           echo "::group::build-appflowy-ai-${{ matrix.job.name }}"
           docker buildx build \
             --platform ${{ matrix.job.docker_platform }} \
@@ -557,7 +561,7 @@ jobs:
             -t ${{ env.IMAGE_NAME }}:${{ env.GIT_TAG }}-${{ matrix.job.name }} \
             --cache-from type=gha,scope=appflowy_ai-${{ matrix.job.name }} \
             --cache-to type=gha,mode=max,scope=appflowy_ai-${{ matrix.job.name }} \
-            --build-arg GITHUB_TOKEN=${{ secrets.ADMIN_GITHUB_TOKEN }} \
+            --secret id=github_token,env=AI_SOURCE_TOKEN \
             --build-arg PROFILE=release \
             --build-arg FEATURES=${{ secrets.CI_APPFLOWY_CLOUD_FEATURES }} \
             --build-arg APP_VERSION=${{ env.GIT_TAG }} \


### PR DESCRIPTION
## Summary

- provide the public Cloud integration workflows with a CI-only `APPFLOWY_AI_DATABASE_URL`
- reuse the existing test Postgres owner over the Compose service network
- pass the private AI source credential to the checked-out AI Dockerfile only as a nonempty BuildKit secret
- keep Cloud Compose and AI private-source boundaries fail-closed

## Why

AppFlowy-Cloud-Premium #1024 requires the AI runtime DSN during Compose/Bake evaluation. These public workflows intentionally copy `deploy.env`, which excludes that secret-only value, so hosted integration jobs otherwise stop before an image is built. The owner DSN added here is test-only; the Cloud role-specific lane separately verifies `appflowy_ai_runtime`.

The coordinated AI Dockerfile now requires a BuildKit source secret. This PR updates the sole AppFlowy-CI AI-image caller without placing the credential in a build argument or image layer.

## Validation

- PyYAML parse and actionlint 1.7.7 for the edited workflows
- explicit nonempty source-token check and unique `--secret id=github_token,env=AI_SOURCE_TOKEN` binding
- positive Docker Bake and Compose parsing against Cloud `37f0c6e87cca371df30dc36a79d503953f02b752`
- negative Bake parsing confirms the Cloud configuration still rejects a missing DSN
- Cloud/AI bilateral workflow validator and negative self-tests pass against this exact CI commit
- Rust lint, all three Rust groups, Windows, and all four iOS mobile runners pass; Linux/macOS Flutter Analyzer failures reproduce pre-existing external AppFlowy-Premium drift and their downstream tests are skipped
- `git diff --check`

## Exact-head attestation

CI HEAD=`e6bacceb130f82b80cf6c1948cf7ba7d093f8b9c`; Cloud/Connectors HEAD=`37f0c6e87cca371df30dc36a79d503953f02b752`, source clean `sha256:42c16bfddc67474ec94936768dd862ece2e8c75db58833bf8c1f173813521ce3`; Cloud image `sha256:7e9ac1e78973a9647c1c31d5abf672b955c4523746d150a1ce43145a3c30e0bf`; Connectors image `sha256:0fd3e12a19cb7ab75bfa35c3dbe28e9e3322f7f87ca5e0a7eb8a82a8dc2e2221`; AI HEAD=`bb3fc10f2fd7b9f58e6c96b7497e18faabd44a4d`, source clean `sha256:ba6b4b3a8eb6c0b53357973e3653eecd3d4c3c61360849a0010e1ee8cc7c6023`, image `sha256:be51f892373e659d019e54a7984fddf8c09dcf9a503ec0f1edc7d49c802e2cb9`. Runner exit 0.

## Coordinated pull requests

- CI workflow (this PR): https://github.com/AppFlowy-IO/AppFlowy-CI/pull/22
- Cloud control plane/contracts: https://github.com/AppFlowy-IO/AppFlowy-Cloud-Premium/pull/1024
- AI runtime: https://github.com/AppFlowy-IO/AppFlowy-AI-Premium/pull/45
- Admin console: https://github.com/AppFlowy-IO/AppFlowy-Admin/pull/79

## Required merge order

1. Merge CI #22 first, but do not dispatch the self-host AI-image workflow during the non-atomic caller/Dockerfile merge window.
2. Verify `OUTBOUND_MCP_RELEASE_AI_SHA=bb3fc10f2fd7b9f58e6c96b7497e18faabd44a4d`, enable/rerun the coordinated Cloud integration gate on Cloud #1024 at `37f0c6e87cca371df30dc36a79d503953f02b752`, then merge Cloud after required checks and reviews pass.
3. If Cloud's merge SHA differs from shared-client/fixture authority `31718a27e866188005f4fc7e86f4106838511ca6`, repin AI #45 and Admin #79 and rerun the coordinated contracts.
4. Merge AI #45 and Admin #79, then deploy in stages.

This PR is intentionally draft and must not be merged as part of this coordination pass.
