### PR TITLE
ci: run permission cache package tests

### DIFF
--- a/.github/workflows/cloud_integration_ci.yaml
+++ b/.github/workflows/cloud_integration_ci.yaml
@@ -585,8 +585,10 @@ jobs:
           sed -i 's/http:\/\/127\.0\.0\.1:8000/http:\/\/127.0.0.1/g' nginx/nginx.conf
           cat nginx/nginx.conf
 
-      - name: Install snapshot recovery test Redis
-        if: matrix.test_service == 'appflowy_worker'
+      - name: Install isolated test Redis
+        if: >-
+          matrix.test_service == 'appflowy_worker' ||
+          matrix.test_service == 'appflowy_cloud_member_packages'
         run: |
           sudo apt-get update
           sudo apt-get install -y redis-server
@@ -715,6 +717,8 @@ jobs:
             echo "==> Testing workspace member packages"
             RUST_LOG="info" DISABLE_CI_TEST_LOG="true" cargo test --locked \
               -p appflowy-collaborate \
+              -p collab-stream \
+              -p workspace-permission \
               -p pdf-exporter \
               -p collab \
               -p collab-rt-entity \

--- a/.github/workflows/cloud_integration_ci.yaml
+++ b/.github/workflows/cloud_integration_ci.yaml
@@ -718,6 +718,7 @@ jobs:
             RUST_LOG="info" DISABLE_CI_TEST_LOG="true" cargo test --locked \
               -p appflowy-collaborate \
               -p collab-stream \
+              -p database \
               -p workspace-permission \
               -p pdf-exporter \
               -p collab \


### PR DESCRIPTION
## Summary

Companion CI coverage for
[AppFlowy-Cloud-Premium#1046](https://github.com/AppFlowy-IO/AppFlowy-Cloud-Premium/pull/1046).

- keep permission-cache tests in the existing member-package runner rather than adding a duplicate
  workflow or runner
- retain the runner's isolated Redis service for Redis-backed permission and restore-fence tests
- add `-p database` so the token-owned mutation reservation and generation-cache unit tests run in
  CI alongside `appflowy-collaborate`, `collab-stream`, and `workspace-permission`

The workflow YAML parses successfully, the runner selector remains unique, and the local affected
package checks/tests pass.
